### PR TITLE
Fix constant check

### DIFF
--- a/bin/php-parse
+++ b/bin/php-parse
@@ -95,9 +95,9 @@ foreach ($files as $file) {
         } elseif ('json-dump' === $operation) {
             fwrite(STDERR, "==> JSON dump:\n");
             $jsonSubstitute = 0;
-            if (defined(JSON_INVALID_UTF8_SUBSTITUTE)) {
+            if (defined('JSON_INVALID_UTF8_SUBSTITUTE')) {
                 $jsonSubstitute = JSON_INVALID_UTF8_SUBSTITUTE;
-            } elseif (defined(JSON_PARTIAL_OUTPUT_ON_ERROR)) {
+            } elseif (defined('JSON_PARTIAL_OUTPUT_ON_ERROR')) {
                 $jsonSubstitute = JSON_PARTIAL_OUTPUT_ON_ERROR;
             }
             echo json_encode($stmts, JSON_PRETTY_PRINT | $jsonSubstitute), "\n";


### PR DESCRIPTION
This PR fixes the missing files issue in the vavkamil/dvwp repo. I couldn't find a minimal example to reproduce the issue, but manually verified that the ast is non-empty for these files when using this version of php-parser with joern. Logs are shown for one of the files below, but the other looks the same (apart from numbers)

### With the fix
```
❯ ./joern-cli/frontends/php2cpg/php2cpg --php-parser-bin ~/code/PHP-Parser/bin/php-parse ~/path/to/dvwp/otherz/search-replace-db/srdb.class.php
...
[INFO ] Start of pass: io.joern.php2cpg.passes.AstCreationPass
[INFO ] Pass io.joern.php2cpg.passes.AstCreationPass completed in 580 ms (7% on mutations). 7826 + 0 changes committed from 1 parts.
```
### Without the fix
```
❯ ./joern-cli/frontends/php2cpg/php2cpg ~/path/to/dvwp/otherz/search-replace-db/srdb.class.php
...
[INFO ] Start of pass: io.joern.php2cpg.passes.AstCreationPass
[INFO ] Pass io.joern.php2cpg.passes.AstCreationPass completed in 102 ms (1% on mutations). 0 + 0 changes committed from 1 parts.
```